### PR TITLE
dfs BOJ 촌수계산 ned

### DIFF
--- a/youngkwon_ned/dfs_bfs/Main.java
+++ b/youngkwon_ned/dfs_bfs/Main.java
@@ -1,0 +1,74 @@
+package youngkwon_ned.dfs_bfs;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+/**
+ * <a href="https://www.acmicpc.net/problem/2644">촌수계산</a>
+ */
+public class Main {
+
+    private static int end, answer = -1;
+    private static boolean[] visited;
+    private static List<List<Integer>> graph = new ArrayList<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        // 방문 여부 배열 생성
+        visited = new boolean[n + 1];
+
+        // 인접 리스트 초기화
+        for (int i = 0; i <= n; i++) {
+            graph.add(new ArrayList<>());
+        }
+
+
+        String s = br.readLine();
+        StringTokenizer st = new StringTokenizer(s);
+        // 관계의 촌수를 구할 시작점과 끝점 구함.
+        int start = Integer.parseInt(st.nextToken());
+        end = Integer.parseInt(st.nextToken());
+
+        // 간선의 갯수
+        int relationCount = Integer.parseInt(br.readLine());
+
+        for (int i = 0; i < relationCount; i++) {
+            StringTokenizer tokenizer = new StringTokenizer(br.readLine());
+            // 촌수를 나타내는 관계에서 시작-끝을 구하고 관계를 담을 인접리스트에 저장
+            int from = Integer.parseInt(tokenizer.nextToken());
+            int to = Integer.parseInt(tokenizer.nextToken());
+            graph.get(from).add(to);
+            graph.get(to).add(from);
+        }
+
+        // 시작점, 촌수
+        dfs(start, 0);
+        System.out.println(answer);
+    }
+
+    private static void dfs(int start, int cnt) {
+        // 탐색을 하는 위치 방문여부 체크
+        visited[start] = true;
+
+        // 인접리스트에서 시작점에 해당하는 리스트 순회
+        for (int x : graph.get(start)) {
+            // 방문하지 않았다면
+            if (!visited[x]) {
+                // 탐색환 해당 위치가 목표점(끝)인지 확인
+                if (x == end) {
+                    // 맞으면 촌수 계산 후 리턴
+                    answer = cnt + 1;
+                    return;
+                }
+                // 아니면 촌수 + 1 후 dfs 계속 진행
+                dfs(x, cnt + 1);
+            }
+        }
+    }
+
+}

--- a/youngkwon_ned/dfs_bfs/Solution1.java
+++ b/youngkwon_ned/dfs_bfs/Solution1.java
@@ -1,4 +1,4 @@
-package youngkwon_ned.week3;
+package youngkwon_ned.dfs_bfs;
 
 import java.io.BufferedReader;
 import java.io.IOException;


### PR DESCRIPTION
https://www.acmicpc.net/problem/2644

#### 왜 이 문제를 선택했나?
- 분류에서 dfs 문제중 사람들이 많이 풀었고, 대회문제여서 어느정도 검증된 문제라고 생각했습니다.

#### 문제 푼 데 걸린 시간은?
- 1시간 30분 초과해서 다른 사람 풀이 참고함.

#### 시간 복잡도는 ? (잘 모르겠다면 예상)
- 잘 몰라서 확인해봣는데, 인접리스트로 구현했는데, 정점에서 연결된 각각의 간선을 모두 탐색하도록 되는데 최악의 경우 연산이 모두 끝나면 Start 에서 연결된 모든 간선을 탐색하게 됨  O(V+E) 라고함.

#### 문제 설명
- 사람의 수와 사람들간의 관계를 나타내는 수가 주어지면 요구한 사람x ,사람y간의 관계를 촌수로 나타내는 문제입니다.

#### 문제 풀이 설명
![image](https://user-images.githubusercontent.com/47075043/218298960-bd5b6ee4-6da0-4fc0-a681-4701355e1447.png)

- dfs 방식으로 풀었습니다.
- 방문 했는지 여부를 체크할 배열과 사람간의 관계를 나타내기 위해 인접리스트를 입력 값으로 초기화하고 dfs 함수를 실행.
- 인접 리스트에서 입력에서 요구한 사람 x의 관계부터 시작해서 간선(관계)으로 이어진 모든 사람(노드)를 탐색 후 촌수 계산